### PR TITLE
Fix barrel exports

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
-  "changelog": "@changesets/cli/changelog",
-  "commit": false,
-  "fixed": [],
-  "linked": [],
-  "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": []
+	"$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
+	"changelog": "@changesets/cli/changelog",
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "public",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": []
 }

--- a/.changeset/rude-jokes-mate.md
+++ b/.changeset/rude-jokes-mate.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/icons': patch
+---
+
+Allow direct import of icons to decrease reliance on treeshaking

--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
 	"author": "six7@hyma.io",
 	"type": "module",
 	"exports": {
-		".": "./dist/index.js"
+		"./*": {
+			"import": "./dist/icons/*",
+			"types": "./dist/icons/*"
+		},
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
 	},
 	"files": [
 		"dist"

--- a/svgr.config.cjs
+++ b/svgr.config.cjs
@@ -1,10 +1,11 @@
+const path = require('path');
 const template = require('./svgr-template.cjs');
 
 // Custom index template to handle file endings as required
 function indexTemplate(filePaths) {
 	const exportEntries = filePaths
 		.map(({ path: filePath }) => {
-			const fileName = filePath.split('/').pop().replace('.tsx', '.js');
+			const fileName = filePath.split(path.sep).pop().replace('.tsx', '.js');
 			const componentName = fileName.replace('.js', '');
 			return `export { default as ${componentName} } from './${fileName}';`;
 		})


### PR DESCRIPTION
Allows direct importing of icon files for cases where treeshaking is not feasible.

Also fixes an issue where generation was not correct on windows path systems